### PR TITLE
Update SMB path regex to make TLD optional

### DIFF
--- a/src/smb_path/path_patch.py
+++ b/src/smb_path/path_patch.py
@@ -7,7 +7,7 @@ import wrapt
 
 from smb_path.smb_path import SmbPath, SmbPosixPath, SmbWindowsPath
 
-_SMB_PATH_REGEX = r"(//|\\\\)([a-z0-9_-]+)((\.[a-z0-9_-]+)*)(\.[a-z]+){1}"
+_SMB_PATH_REGEX = r"(//|\\\\)([a-z0-9_-]+)((\.[a-z0-9_-]+)*)(\.[a-z]+)?"
 
 
 if sys.version_info >= (3, 12):


### PR DESCRIPTION
Just making the change proposed in the issue I just opened.

Also did some testing of the regex in regex101 to try and make sure it still works as expected + allows hostnames without a TLD:
<img width="815" height="864" alt="image" src="https://github.com/user-attachments/assets/dc65fab9-c705-4411-a360-f473715cc9f9" />


fixes: #10 